### PR TITLE
Fix manual fire guns crashing

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -202,7 +202,6 @@ local function on_lclick(stack, player)
 			stack = reload(stack, player)
 			meta:set_string("loaded", "true")
 		end
-		stack:set_meta(meta)
 	end
 
 	return stack


### PR DESCRIPTION
there is no set_meta method, set_string() works fine by itself.