### PR TITLE
Fix non automatic guns not firing more than once

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -239,7 +239,7 @@ local function on_step(dtime)
 			end
 			if player:get_player_control().LMB then
 				-- If LMB pressed, fire
-				info.stack = fire(info.stack, player, info.def.base_spread, info.def.max_spread, info.def.pellets)
+				info.stack = fire(info.stack, player)
 				player:set_wielded_item(info.stack)
 				automatic[name].stack = info.stack
 				interval[name] = 0

--- a/api.lua
+++ b/api.lua
@@ -224,34 +224,34 @@ end
 --------------------------------
 
 local function on_step(dtime)
-	for name, info in pairs(automatic) do
-		local player = minetest.get_player_by_name(name)
-		if not player then
-			automatic[name] = nil
-			return
-		end
-
+	for name in pairs(interval) do
 		interval[name] = interval[name] + dtime
-		if interval[name] < info.def.unit_time then
-			return
-		end
-
-		if player:get_player_control().LMB then
-			-- If LMB pressed, fire
-			info.stack = fire(info.stack, player)
-			player:set_wielded_item(info.stack)
-			automatic[name].stack = info.stack
-			interval[name] = 0
-		else
-			-- If LMB not pressed, remove player from list
-			automatic[name] = nil
+	end
+	if not lite then
+		for name, info in pairs(automatic) do
+			local player = minetest.get_player_by_name(name)
+			if not player then
+				automatic[name] = nil
+				return
+			end
+			if interval[name] < info.def.unit_time then
+				return
+			end
+			if player:get_player_control().LMB then
+				-- If LMB pressed, fire
+				info.stack = fire(info.stack, player, info.def.base_spread, info.def.max_spread, info.def.pellets)
+				player:set_wielded_item(info.stack)
+				automatic[name].stack = info.stack
+				interval[name] = 0
+			else
+				-- If LMB not pressed, remove player from list
+				automatic[name] = nil
+			end
 		end
 	end
 end
 
-if not lite then
-	minetest.register_globalstep(on_step)
-end
+minetest.register_globalstep(on_step)
 
 --
 -- External API functions


### PR DESCRIPTION
Since all guns use interval[] to know when they can be shot again, and dtime was only being added for automatic weapons. semi-automatic, burst, and manual weapons would only fire once, then nothing would fire until the server restarted, even automatic weapons.
pretty simple fix, make interval get dtime added for all weapons, even in lite mode.
if you want lite mode to use no globalstep then you'll have to have the weapons not use interval as well, otherwise they wont shoot more than once.