### PR TITLE
add support for hitscan weapons

### DIFF
--- a/API.md
+++ b/API.md
@@ -135,6 +135,10 @@ The `gunslinger` namespace has the following members:
   - `"automatic"`: Fully automatic; shoots as long as primary button is held down. e.g. AKM, M416.
   - `"hybrid"`: Same as `"automatic"`, but switches to `"burst"` mode when scope view is toggled.
 
+- `hit_type` [string]: Weapon hit detection type, defaults to projectile.
+  - `"hitscan"`: Gun deals damage to the pointed target instantly, bullets have no travel time.
+  - `"projectile"`: Bullets are modeled as projectiles, more realistic. 
+
 - `ammo` [string]: Name of valid registered item to be used as ammo for the gun. Defaults to `gunslinger:ammo`.
 - `dmg_mult` [number]: Damage multiplier. Multiplied with `base_dmg` to obtain initial/rated damage value. Defaults to 1.
 - `spread_mult` [number]: Spread multiplier. Multiplied with `base_spread` to obtain spread threshold for projectile. Defaults to 0.

--- a/api.lua
+++ b/api.lua
@@ -165,6 +165,7 @@ end
 -- hit the target
 local function hit_target(obj, pos, look_dir, gun_def, init_pointed)
 	-- this is here because of minetest.after
+	local pointed
 	if init_pointed ~= 0 then
 		pointed = init_pointed
 	else

--- a/api.lua
+++ b/api.lua
@@ -66,7 +66,6 @@ local function add_auto(name, def, stack)
 end
 
 local function validate_def(def)
-	-- lmao
 	if type(def) ~= "table" then
 		error("gunslinger.register_gun: Gun definition has to be a table!", 2)
 	end

--- a/api.lua
+++ b/api.lua
@@ -83,6 +83,10 @@ local function validate_def(def)
 		def.burst = rangelim(2, def.burst, 5, 3)
 	end
 
+	if not def.hit_type then
+		def.hit_type = "projectile"
+	end
+
 	def.dmg_mult = rangelim(1, def.dmg_mult, 100, 1)
 	def.reload_time = rangelim(1, def.reload_time, 10, 2.5)
 	def.spread_mult = rangelim(0, def.spread_mult, 500, 0)
@@ -177,74 +181,120 @@ local function fire(stack, player)
 	-- Play gunshot sound
 	play_sound(def.sounds.fire, player)
 
-	--[[
-		Perform "deferred raycasting" to mimic projectile entities, without
-		actually using entities:
-			- Perform initial raycast to get position of target if it exists
-			- Calculate time taken for projectile to travel from gun to target
-			- Perform actual raycast after the calculated time
-
-		This process throws in a couple more calculations and an extra raycast,
-		but the vastly improved realism at the cost of a negligible performance
-		hit is always great to have.
-	]]
-	local time = 0.1 -- Default to 0.1s
-
 	local dir = player:get_look_dir()
-
 	local pos1 = get_eye_pos(player)
 	pos1 = vector.add(pos1, dir)
-	local initial_pthing = get_pointed_thing(pos1, dir, def)
-	if initial_pthing then
-		local pos2 = minetest.get_pointed_thing_position(initial_pthing)
-		time = vector.distance(pos1, pos2) / config.projectile_speed
-	end
-
 	local random = PcgRandom(os.time())
 
-	for i = 1, def.pellets do
-		-- Mimic inaccuracy by applying randomised miniscule deviations
-		if def.spread_mult ~= 0 then
-			dir = vector.apply(dir, function(n)
-				return n + random:next(-def.spread_mult, def.spread_mult) * config.base_spread
-			end)
+	-- handle hitscan / projectile weapons
+	if def.hit_type == "hitscan" then
+		local pointed = get_pointed_thing(pos1, dir, def)
+
+		for i = 1, def.pellets do
+			-- Mimic inaccuracy by applying randomised miniscule deviations
+			if def.spread_mult ~= 0 then
+				dir = vector.apply(dir, function(n)
+					return n + random:next(-def.spread_mult, def.spread_mult) * config.base_spread
+				end)
+			end
+
+			if pointed and pointed.type == "object" then
+					local target = pointed.ref
+					if target:get_player_name() ~= player:get_player_name() then
+						local point = pointed.intersection_point
+						local dmg = config.base_dmg * def.dmg_mult
+
+						-- Add 50% damage if headshot
+						if point.y > target:get_pos().y + 1.2 then
+							dmg = dmg * 1.5
+						end
+
+						-- Add 20% more damage if player using scope
+						if gunslinger.__scopes[player:get_player_name()] then
+							dmg = dmg * 1.2
+						end
+
+						target:punch(player, nil, {damage_groups = {fleshy = dmg}})
+					end
+				end
+
+			-- Projectile particle
+			minetest.add_particle({
+				pos = pos1,
+				velocity = vector.multiply(dir, config.projectile_speed),
+				acceleration = {x = 0, y = 0, z = 0},
+				expirationtime = 3,
+				size = 3,
+				collisiondetection = true,
+				collision_removal = true,
+				object_collision = true,
+				glow = 10
+			})
 		end
 
-		minetest.after(time, function(obj, pos, look_dir, gun_def)
-			local pointed = get_pointed_thing(pos, look_dir, gun_def)
-			if pointed and pointed.type == "object" then
-				local target = pointed.ref
-				if target:get_player_name() ~= obj:get_player_name() then
-					local point = pointed.intersection_point
-					local dmg = config.base_dmg * gun_def.dmg_mult
+	else
+		--[[
+			Perform "deferred raycasting" to mimic projectile entities, without
+			actually using entities:
+				- Perform initial raycast to get position of target if it exists
+				- Calculate time taken for projectile to travel from gun to target
+				- Perform actual raycast after the calculated time
 
-					-- Add 50% damage if headshot
-					if point.y > target:get_pos().y + 1.2 then
-						dmg = dmg * 1.5
-					end
+			This process throws in a couple more calculations and an extra raycast,
+			but the vastly improved realism at the cost of a negligible performance
+			hit is always great to have.
+		]]
+		local time = 0.1 -- Default to 0.1s
+		local initial_pthing = get_pointed_thing(pos1, dir, def)
+		if initial_pthing then
+			local pos2 = minetest.get_pointed_thing_position(initial_pthing)
+			time = vector.distance(pos1, pos2) / config.projectile_speed
+		end
 
-					-- Add 20% more damage if player using scope
-					if gunslinger.__scopes[obj:get_player_name()] then
-						dmg = dmg * 1.2
-					end
-
-					target:punch(obj, nil, {damage_groups = {fleshy = dmg}})
-				end
+		for i = 1, def.pellets do
+			-- Mimic inaccuracy by applying randomised miniscule deviations
+			if def.spread_mult ~= 0 then
+				dir = vector.apply(dir, function(n)
+					return n + random:next(-def.spread_mult, def.spread_mult) * config.base_spread
+				end)
 			end
-		end, player, pos1, dir, def)
 
-		-- Projectile particle
-		minetest.add_particle({
-			pos = pos1,
-			velocity = vector.multiply(dir, config.projectile_speed),
-			acceleration = {x = 0, y = 0, z = 0},
-			expirationtime = 3,
-			size = 3,
-			collisiondetection = true,
-			collision_removal = true,
-			object_collision = true,
-			glow = 10
-		})
+			minetest.after(time, function(obj, pos, look_dir, gun_def)
+				local pointed = get_pointed_thing(pos, look_dir, gun_def)
+				if pointed and pointed.type == "object" then
+					local target = pointed.ref
+					if target:get_player_name() ~= obj:get_player_name() then
+						local point = pointed.intersection_point
+						local dmg = config.base_dmg * gun_def.dmg_mult
+
+						-- Add 50% damage if headshot
+						if point.y > target:get_pos().y + 1.2 then
+							dmg = dmg * 1.5
+						end
+
+						-- Add 20% more damage if player using scope
+						if gunslinger.__scopes[obj:get_player_name()] then
+							dmg = dmg * 1.2
+						end
+
+						target:punch(obj, nil, {damage_groups = {fleshy = dmg}})
+					end
+				end
+			end, player, pos1, dir, def)
+
+			-- Projectile particle
+			minetest.add_particle({
+				pos = pos1,
+				velocity = vector.multiply(dir, config.projectile_speed),
+				acceleration = {x = 0, y = 0, z = 0},
+				expirationtime = 3,
+				size = 3,
+				collisiondetection = true,
+				collision_removal = true,
+				object_collision = true,
+				glow = 10
+			})
+		end
 	end
 
 	-- Simulate recoil

--- a/guns.lua
+++ b/guns.lua
@@ -14,22 +14,4 @@ gunslinger.register_gun("gunslinger:cheetah", {
 	range = 80
 })
 
-gunslinger.register_gun("gunslinger:hitscan", {
-	itemdef = {
-		description = "hitscan",
-		inventory_image = "gunslinger_cheetah.png",
-		wield_image = "gunslinger_cheetah.png^[transformFXR300",
-		wield_scale = {x = 3, y = 3, z = 1}
-	},
-
-	mode = "manual",
-	hit_type = "hitscan",
-	dmg_mult = 5,
-	recoil_mult = 5,
-	fire_rate = 3,
-	clip_size = 1,
-	range = 200
-})
-
 minetest.register_alias("cheetah", "gunslinger:cheetah")
-minetest.register_alias("hitscan", "gunslinger:hitscan")

--- a/guns.lua
+++ b/guns.lua
@@ -14,4 +14,22 @@ gunslinger.register_gun("gunslinger:cheetah", {
 	range = 80
 })
 
+gunslinger.register_gun("gunslinger:hitscan", {
+	itemdef = {
+		description = "hitscan",
+		inventory_image = "gunslinger_cheetah.png",
+		wield_image = "gunslinger_cheetah.png^[transformFXR300",
+		wield_scale = {x = 3, y = 3, z = 1}
+	},
+
+	mode = "manual",
+	hit_type = "hitscan",
+	dmg_mult = 5,
+	recoil_mult = 5,
+	fire_rate = 3,
+	clip_size = 1,
+	range = 200
+})
+
 minetest.register_alias("cheetah", "gunslinger:cheetah")
+minetest.register_alias("hitscan", "gunslinger:hitscan")


### PR DESCRIPTION
Add hitscan weapons, nice to have for sniper rifles like the AWP or for quake style railguns.
(basically all the counterstrike guns are hitscan, coz the maps are small)

Can even serve as a "lite mode" alternative to projectile weapons.